### PR TITLE
docs: update setup script references

### DIFF
--- a/content/blog/architecture-decisions-in-the-code-repository.en.md
+++ b/content/blog/architecture-decisions-in-the-code-repository.en.md
@@ -31,7 +31,7 @@ ADRs have no single canonical standard. vanityURLs follows the practical convent
 
 The decision belongs where the implementation changes.
 
-If a commit modifies `scripts/install.mjs`, `defaults/v8s-site-config.json`, and a schema rule, the ADR can travel with that commit. Reviewers see the code and the reason together.
+If a commit modifies `scripts/setup.mjs`, `defaults/v8s-site-config.json`, and a schema rule, the ADR can travel with that commit. Reviewers see the code and the reason together.
 
 That keeps the public website shorter. The website can say what to do. The ADR can preserve why the product behaves that way.
 

--- a/content/blog/architecture-decisions-in-the-code-repository.fr.md
+++ b/content/blog/architecture-decisions-in-the-code-repository.fr.md
@@ -31,7 +31,7 @@ Les ADR n'ont pas de standard canonique unique. vanityURLs suit la convention pr
 
 La décision appartient la ou l'implementation change.
 
-Si un commit modifie `scripts/install.mjs`, `defaults/v8s-site-config.json` et une règle de schéma, l'ADR peut voyager avec ce commit. Les reviewers voient le code et la raison ensemble.
+Si un commit modifie `scripts/setup.mjs`, `defaults/v8s-site-config.json` et une règle de schéma, l'ADR peut voyager avec ce commit. Les reviewers voient le code et la raison ensemble.
 
 Cela garde le site public plus court. Le site peut dire quoi faire. L'ADR peut conserver pourquoi le produit fonctionne ainsi.
 

--- a/content/docs/reference/repository-layout.en.md
+++ b/content/docs/reference/repository-layout.en.md
@@ -49,7 +49,7 @@ The public [v8s.link repository](https://github.com/vanityURLs/v8s.link) follows
 {{< /filetree/folder >}}
 {{< filetree/file name="lnk" annotation="CLI for links, schedules, and policy workflows" >}}
 {{< filetree/file name="build.mjs" annotation="build defaults plus custom into deploy output" >}}
-{{< filetree/file name="install.mjs" annotation="npm run setup" >}}
+{{< filetree/file name="setup.mjs" annotation="npm run setup" >}}
 {{< filetree/file name="upgrade.mjs" annotation="npm run upgrade" >}}
 {{< filetree/file name="local-install.mjs" annotation="local helper setup" >}}
 {{< filetree/file name="v8s.sh" annotation="read-only local helper" >}}

--- a/content/docs/reference/repository-layout.fr.md
+++ b/content/docs/reference/repository-layout.fr.md
@@ -49,7 +49,7 @@ Le dépôt public [v8s.link](https://github.com/vanityURLs/v8s.link) suit cette 
 {{< /filetree/folder >}}
 {{< filetree/file name="lnk" annotation="CLI pour liens, horaires et politique" >}}
 {{< filetree/file name="build.mjs" annotation="build defaults plus custom vers la sortie de déploiement" >}}
-{{< filetree/file name="install.mjs" annotation="npm run setup" >}}
+{{< filetree/file name="setup.mjs" annotation="npm run setup" >}}
 {{< filetree/file name="upgrade.mjs" annotation="npm run upgrade" >}}
 {{< filetree/file name="local-install.mjs" annotation="setup du helper local" >}}
 {{< filetree/file name="v8s.sh" annotation="helper local en lecture seule" >}}


### PR DESCRIPTION
This Pull Request updates website documentation references after the code repository renamed the setup implementation from `scripts/install.mjs` to `scripts/setup.mjs`.

### Detail

This PR updates:

- repository layout references in English and French
- architecture decision blog examples in English and French

The user-facing command remains `npm run setup`.

### Checks

- [x] `npm run format:check`
- [x] `npm run test`
- [x] `npm run build`
- [x] `npm run lint`
